### PR TITLE
fix #20

### DIFF
--- a/anki_ocr/ocr.py
+++ b/anki_ocr/ocr.py
@@ -257,7 +257,7 @@ class OCR:
                 os.unsetenv("OMP_THREAD_LIMIT")
             except:
                 pass
-        tessdata_config = f'--tessdata-dir "{TESSDATA_DIR.absolute()}"'
+        tessdata_config = f'--oem 1 --tessdata-dir "{TESSDATA_DIR.absolute()}"'
 
         return pytesseract.image_to_string(str(img_pth), lang="+".join(languages or ["eng"]),
                                            config=tessdata_config)


### PR DESCRIPTION
fix for https://github.com/cfculhane/AnkiOCR/issues/20

I just followed advice from https://github.com/tesseract-ocr/tesseract/issues/1205

Note that `--oem 2` doesn't solve the issue.

`tesseract --help-oem` shows this output : 
```
OCR Engine modes: (see https://github.com/tesseract-ocr/tesseract/wiki#linux)
  0    Legacy engine only.
  1    Neural nets LSTM engine only.
  2    Legacy + LSTM engines.
  3    Default, based on what is available.
```

So I'm guessing the issue is with the legacy engine.